### PR TITLE
Implement gym retrieval service and fix GeoPoint mapping

### DIFF
--- a/src/main/java/com/jomeerkatz/gym/controllers/GymController.java
+++ b/src/main/java/com/jomeerkatz/gym/controllers/GymController.java
@@ -11,8 +11,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
 
 @RestController
 @RequestMapping(path = "/api/gyms")
@@ -39,8 +42,19 @@ public class GymController {
             @RequestParam(defaultValue = "1") int page, // actually starting at index  0, so we need to get sure to
             // implement it right in frontend
             @RequestParam(defaultValue = "20") int size
-    ){
+    ) {
+        System.out.println("🔎 searchGyms called with:");
+        System.out.println("   latitude = " + latitude);
+        System.out.println("   longitude = " + longitude);
+        System.out.println("   radius = " + radius);
         Page<Gym> searchResult = gymService.searchGyms(query, minRating, latitude, longitude, radius, PageRequest.of(page - 1, size));
         return searchResult.map(gymMapper::toSummaryDto);
+    }
+
+    @GetMapping("/{gym_id}")
+    public ResponseEntity<GymDto> getGym(@PathVariable("gym_id") String gymId) {
+        return gymService.getGym(gymId)
+                .map(gym -> ResponseEntity.ok(gymMapper.toGymDto(gym)))
+                .orElseGet(() -> ResponseEntity.notFound().build());
     }
 }

--- a/src/main/java/com/jomeerkatz/gym/domain/dtos/GeoPointDto.java
+++ b/src/main/java/com/jomeerkatz/gym/domain/dtos/GeoPointDto.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class GeoPointDto {
-    private Double latitude;
-    private Double longitude;
+    private Double lat;
+    private Double lon;
 }

--- a/src/main/java/com/jomeerkatz/gym/mappers/GymMapper.java
+++ b/src/main/java/com/jomeerkatz/gym/mappers/GymMapper.java
@@ -16,6 +16,7 @@ import java.util.List;
 public interface GymMapper {
 
     GymCreateUpdateRequest toGymCreateUpdateRequest(GymCreateUpdateRequestDto dto);
+
     GymDto toGymDto(Gym gym);
 
     @Mapping(source = "reviews", target = "totalReviews", qualifiedByName = "populateTotalReviews")
@@ -25,9 +26,4 @@ public interface GymMapper {
     default Integer populateTotalReviews(List<Review> reviewList){
         return reviewList.size();
     }
-
-//    @AfterMapping
-//    default void logSummaryDto(@MappingTarget GymSummaryDto dto) {
-//        System.out.println("SUMMARY DTO ADDRESS: " + dto.getAddress());
-//    }
 }

--- a/src/main/java/com/jomeerkatz/gym/services/GymService.java
+++ b/src/main/java/com/jomeerkatz/gym/services/GymService.java
@@ -5,6 +5,8 @@ import com.jomeerkatz.gym.domain.entities.Gym;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Optional;
+
 public interface GymService {
     Gym createGym(GymCreateUpdateRequest request);
 
@@ -16,4 +18,6 @@ public interface GymService {
             Float radius,
             Pageable pageable
     );
+
+    Optional<Gym> getGym(String id);
 }

--- a/src/main/java/com/jomeerkatz/gym/services/impl/GymServiceImpl.java
+++ b/src/main/java/com/jomeerkatz/gym/services/impl/GymServiceImpl.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @AllArgsConstructor
@@ -64,5 +65,10 @@ public class GymServiceImpl implements GymService {
         }
 
         return gymRepository.findAll(pageable);
+    }
+
+    @Override
+    public Optional<Gym> getGym(String id) {
+        return gymRepository.findById(id);
     }
 }


### PR DESCRIPTION
### Summary
This PR adds the gym retrieval service and fixes the incorrect GeoPoint mapping in the backend.

### Changes
- Implemented service to retrieve a single gym by ID
- Added endpoint `/api/gyms/{id}` to return full GymDto
- Fixed GeoPoint → GeoPointDto mapping (lat/lon now correct)
- Updated DTO models to match backend JSON
- Cleaned up naming inconsistencies related to geoLocation
- Verified correct JSON output for gym detail endpoint

### Result
- Frontend can now fetch gym details reliably
- geoLocation (lat/lon) is properly populated and no longer null
- Detail page can now trigger nearby gyms lookup successfully